### PR TITLE
Ensure Uniqueness

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ function single(key, dep) {
 }
 
 function multi(keys, dep, base) {
-	base = base || dep.split('/').pop().replace(/\W/g, '_') + '$' + NAMED.num++; // uniqueness
+	base = base || dep.split('/').pop().replace(/\W/g, '_') + '$' + num++; // uniqueness
 	let obj, out = single(base, dep);
 	keys.split(',').forEach(key => {
 		obj = alias(key);
@@ -24,8 +24,9 @@ function multi(keys, dep, base) {
 	return out;
 }
 
+let num;
 module.exports = function (str) {
-	NAMED.num = 0;
+	num = 0;
 	return str
 		.replace(NAMED, (_, base, req, dep) => req ? multi(req, dep, base) : single(base, dep))
 		.replace(UNNAMED, (_, dep) => `require('${dep}');`);

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ function single(key, dep) {
 }
 
 function multi(keys, dep, base) {
-	base = base || dep.split('/').pop().replace(/\W/g, '_') + '$1'; // uniqueness
+	base = base || dep.split('/').pop().replace(/\W/g, '_') + '$' + NAMED.num++; // uniqueness
 	let obj, out = single(base, dep);
 	keys.split(',').forEach(key => {
 		obj = alias(key);
@@ -25,6 +25,7 @@ function multi(keys, dep, base) {
 }
 
 module.exports = function (str) {
+	NAMED.num = 0;
 	return str
 		.replace(NAMED, (_, base, req, dep) => req ? multi(req, dep, base) : single(base, dep))
 		.replace(UNNAMED, (_, dep) => `require('${dep}');`);

--- a/test/index.js
+++ b/test/index.js
@@ -58,13 +58,13 @@ test(`import foo from "../foo/bar";`, t => {
 // Partial Imports
 
 test(`import { foo, bar } from 'baz'`, t => {
-	const out = `const baz$1 = require('baz');\nconst foo = baz$1.foo;\nconst bar = baz$1.bar;`;
+	const out = `const baz$0 = require('baz');\nconst foo = baz$0.foo;\nconst bar = baz$0.bar;`;
 	t.is(fn(`import { foo, bar } from 'baz'`), out);
 	t.end();
 });
 
 test(`import { foo, bar } from '../baz'`, t => {
-	const out = `const baz$1 = require('../baz');\nconst foo = baz$1.foo;\nconst bar = baz$1.bar;`
+	const out = `const baz$0 = require('../baz');\nconst foo = baz$0.foo;\nconst bar = baz$0.bar;`
 	t.is(fn(`import { foo, bar } from '../baz'`), out);
 	t.end();
 });
@@ -114,13 +114,13 @@ test(`import foo from'foo'`, t => {
 });
 
 test(`import{foo,bar}from'baz'`, t => {
-	const out = `const baz$1 = require('baz');\nconst foo = baz$1.foo;\nconst bar = baz$1.bar;`;
+	const out = `const baz$0 = require('baz');\nconst foo = baz$0.foo;\nconst bar = baz$0.bar;`;
 	t.is(fn(`import{foo,bar}from'baz'`), out);
 	t.end();
 });
 
 test(`import{foo,bar}from'../baz'`, t => {
-	const out = `const baz$1 = require('../baz');\nconst foo = baz$1.foo;\nconst bar = baz$1.bar;`
+	const out = `const baz$0 = require('../baz');\nconst foo = baz$0.foo;\nconst bar = baz$0.bar;`
 	t.is(fn(`import{foo,bar}from'../baz'`), out);
 	t.end();
 });
@@ -133,7 +133,7 @@ test(`import foo from "foo-bar"`, t => {
 });
 
 test(`import {foo, bar} from 'foo-bar'`, t => {
-	const out = `const foo_bar$1 = require('foo-bar');\nconst foo = foo_bar$1.foo;\nconst bar = foo_bar$1.bar;`
+	const out = `const foo_bar$0 = require('foo-bar');\nconst foo = foo_bar$0.foo;\nconst bar = foo_bar$0.bar;`
 	t.is(fn(`import {foo, bar} from 'foo-bar'`), out);
 	t.end();
 });
@@ -141,29 +141,29 @@ test(`import {foo, bar} from 'foo-bar'`, t => {
 // Aliases
 
 test(`import { default as main } from 'foo'`, t => {
-	t.is(fn(`import { default as main } from 'foo'`), `const foo$1 = require('foo');\nconst main = foo$1.default;`);
+	t.is(fn(`import { default as main } from 'foo'`), `const foo$0 = require('foo');\nconst main = foo$0.default;`);
 	t.end();
 });
 
 test(`import { foo as bar } from 'baz'`, t => {
-	t.is(fn(`import { foo as bar } from 'baz'`), `const baz$1 = require('baz');\nconst bar = baz$1.foo;`);
+	t.is(fn(`import { foo as bar } from 'baz'`), `const baz$0 = require('baz');\nconst bar = baz$0.foo;`);
 	t.end();
 });
 
 test(`import { bar, default as main } from '../foo'`, t => {
-	const out = `const foo$1 = require('../foo');\nconst bar = foo$1.bar;\nconst main = foo$1.default;`
+	const out = `const foo$0 = require('../foo');\nconst bar = foo$0.bar;\nconst main = foo$0.default;`
 	t.is(fn(`import { bar, default as main } from '../foo'`), out);
 	t.end();
 });
 
 test(`import { foo as bar, default as main } from '../foo'`, t => {
-	const out = `const foo$1 = require('../foo');\nconst bar = foo$1.foo;\nconst main = foo$1.default;`
+	const out = `const foo$0 = require('../foo');\nconst bar = foo$0.foo;\nconst main = foo$0.default;`
 	t.is(fn(`import { foo as bar, default as main } from '../foo'`), out);
 	t.end();
 });
 
 test(`import {foo as bar, default as main} from '../foo'`, t => {
-	const out = `const foo$1 = require('../foo');\nconst bar = foo$1.foo;\nconst main = foo$1.default;`
+	const out = `const foo$0 = require('../foo');\nconst bar = foo$0.foo;\nconst main = foo$0.default;`
 	t.is(fn(`import {foo as bar, default as main} from '../foo'`), out);
 	t.end();
 });
@@ -195,7 +195,7 @@ test(`multi-line -- named`, t => {
 		bar,
 		bat as baz
 	} from 'baz'`;
-	const out = `const baz$1 = require('baz');\nconst foo = baz$1.foo;\nconst bar = baz$1.bar;\nconst baz = baz$1.bat;`;
+	const out = `const baz$0 = require('baz');\nconst foo = baz$0.foo;\nconst bar = baz$0.bar;\nconst baz = baz$0.bat;`;
 	t.is(fn(str), out);
 	t.end();
 });
@@ -206,7 +206,7 @@ test(`multi-line -- relative`, t => {
 		bar,
 		bat as baz
 	} from '../baz'`;
-	const out = `const baz$1 = require('../baz');\nconst foo = baz$1.foo;\nconst bar = baz$1.bar;\nconst baz = baz$1.bat;`
+	const out = `const baz$0 = require('../baz');\nconst foo = baz$0.foo;\nconst bar = baz$0.bar;\nconst baz = baz$0.bat;`
 	t.is(fn(str), out);
 	t.end();
 });
@@ -219,7 +219,7 @@ test(`import foo from 'foo';import bar from 'bar';`, t => {
 });
 
 test(`import foo from 'foo'\\nimport { baz1, baz2 } from 'baz'`, t => {
-	t.is(fn(`import foo from 'foo'\nimport { baz1, baz2 } from 'baz'`), `const foo = require('foo');\nconst baz$1 = require('baz');\nconst baz1 = baz$1.baz1;\nconst baz2 = baz$1.baz2;`);
+	t.is(fn(`import foo from 'foo'\nimport { baz1, baz2 } from 'baz'`), `const foo = require('foo');\nconst baz$0 = require('baz');\nconst baz1 = baz$0.baz1;\nconst baz2 = baz$0.baz2;`);
 	t.end();
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -232,3 +232,23 @@ test(`import './foo'\\nimport 'bar'`, t => {
 	t.is(fn(`import './foo'\nimport 'bar'`), `require('./foo');\nrequire('bar');`);
 	t.end();
 });
+
+// Ensure Uniqueness
+
+test(`import { promisify } from 'util';import { foo as bar } from './util';`, t => {
+	const out = `const util$0 = require('util');\nconst promisify = util$0.promisify;const util$1 = require('./util');\nconst bar = util$1.foo;`;
+	t.is(fn(`import { promisify } from 'util';import { foo as bar } from './util';`), out);
+	t.end();
+});
+
+test(`import util, { promisify } from 'util';import { foo as bar } from './util';`, t => {
+	const out = `const util = require('util');\nconst promisify = util.promisify;const util$0 = require('./util');\nconst bar = util$0.foo;`;
+	t.is(fn(`import util, { promisify } from 'util';import { foo as bar } from './util';`), out);
+	t.end();
+});
+
+test(`import { h } from 'preact';import { Component } from 'preact';`, t => {
+	const out = `const preact$0 = require('preact');\nconst h = preact$0.h;const preact$1 = require('preact');\nconst Component = preact$1.Component;`;
+	t.is(fn(`import { h } from 'preact';import { Component } from 'preact';`), out);
+	t.end();
+});


### PR DESCRIPTION
Importing from the same module twice would throw an error when running the transformed code. While this doesn't happen much in user land (well, isn't supposed to), something like the Babel JSX injector plugin will do this on your behalf. AKA:

```js
// import { h } from 'preact'; // <~ injected
import { Component } from 'preact';
```

Similarly, if/when importing a local file that matches a dependency name, you'd be in trouble. Typically, I require from the `util` module _and_ always have my own file/dir named `util`. I'm sure others do something like this from time to time.