### PR TITLE
Support importing ESM modules with .default key

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 
 const UNNAMED = /import\s*['"]([^'"]+)['"];?/gi;
 const NAMED = /import\s*(\*\s*as)?\s*(\w*?)\s*,?\s*(?:\{([\s\S]*?)\})?\s*from\s*['"]([^'"]+)['"];?/gi;
+const interop = `function ri$interop(m){return m.default||m}\n`;
 
 function alias(key) {
 	key = key.trim();
@@ -11,31 +12,29 @@ function alias(key) {
 }
 
 function generate(keys, dep, base) {
-	let obj, out = '',
-		tmp = base || (dep.split('/').pop().replace(/\W/g, '_') + '$' + num++); // uniqueness
+	let tmp = base || (dep.split('/').pop().replace(/\W/g, '_') + '$' + num++); // uniqueness
+	let name = base || alias(tmp).name;
 
-	if (base) {
-		if (!hasInterop) {
-			out = `function ri$interop(m) { return m.default || m }\n`;
-			hasInterop = true;
-		}
-		out += `const ${base} = ri$interop(require('${dep}'));`;
+	let obj, out='';
+	if (base && !hasInterop) {
+		hasInterop = true;
+		out += interop;
 	}
-	else {
-		out += `const ${alias(tmp).name} = require('${dep}');`;
-	}
+
+	dep = `require('${dep}')`;
+	out += `const ${name} = ` + (base ? `ri$interop(${dep})` : dep) + ';';
 
 	keys.forEach(key => {
 		obj = alias(key);
 		out += `\nconst ${obj.name} = ${tmp}.${obj.key};`;
 	});
+
 	return out;
 }
 
 let num, hasInterop;
 module.exports = function (str) {
-	num = 0;
-	hasInterop = false;
+	num = hasInterop = 0;
 	return str
 		.replace(NAMED, (_, asterisk, base, req, dep) => generate(req ? req.split(',') : [], dep, base))
 		.replace(UNNAMED, (_, dep) => `require('${dep}');`);

--- a/test/index.js
+++ b/test/index.js
@@ -1,282 +1,281 @@
 const test = require('tape');
 const fn = require('../src');
 
-// Single quotes
+[
+	// Single quotes
+	[
+		`import foo from 'foo'`,
+		`function ri$interop(m) { return m.default || m }
+const foo = ri$interop(require('foo'));`
+	],
+	[
+		`import foo from 'foo';`,
+		`function ri$interop(m) { return m.default || m }
+const foo = ri$interop(require('foo'));`
+	],
+	[
+		`import foo from './foo'`,
+		`function ri$interop(m) { return m.default || m }
+const foo = ri$interop(require('./foo'));`
+	],
+	[
+		`import foo from '../foo/bar'`,
+		`function ri$interop(m) { return m.default || m }
+const foo = ri$interop(require('../foo/bar'));`
+	],
+	[
+		`import foo from '../foo/bar';`,
+		`function ri$interop(m) { return m.default || m }
+const foo = ri$interop(require('../foo/bar'));`
+	],
 
-test(`import foo from 'foo'`, t => {
-	t.is(fn(`import foo from 'foo'`), `const foo$0 = require('foo');\nconst foo = foo$0.default || foo$0;`);
-	t.end();
-});
+	// Double quotes
+	[
+		`import foo from "foo"`,
+		`function ri$interop(m) { return m.default || m }
+const foo = ri$interop(require('foo'));`
+	],
+	[
+		`import foo from "foo";`,
+		`function ri$interop(m) { return m.default || m }
+const foo = ri$interop(require('foo'));`
+	],
+	[
+		`import foo from "./foo"`,
+		`function ri$interop(m) { return m.default || m }
+const foo = ri$interop(require('./foo'));`
+	],
+	[
+		`import foo from "../foo/bar"`,
+		`function ri$interop(m) { return m.default || m }
+const foo = ri$interop(require('../foo/bar'));`
+	],
+	[
+		`import foo from "../foo/bar";`,
+		`function ri$interop(m) { return m.default || m }
+const foo = ri$interop(require('../foo/bar'));`
+	],
 
-test(`import foo from 'foo';`, t => {
-	t.is(fn(`import foo from 'foo';`), `const foo$0 = require('foo');\nconst foo = foo$0.default || foo$0;`);
-	t.end();
-});
-
-test(`import foo from './foo'`, t => {
-	t.is(fn(`import foo from './foo'`), `const foo$0 = require('./foo');\nconst foo = foo$0.default || foo$0;`);
-	t.end();
-});
-
-test(`import foo from '../foo/bar'`, t => {
-	t.is(fn(`import foo from '../foo/bar'`), `const foo$0 = require('../foo/bar');\nconst foo = foo$0.default || foo$0;`);
-	t.end();
-});
-
-test(`import foo from '../foo/bar';`, t => {
-	t.is(fn(`import foo from '../foo/bar';`), `const foo$0 = require('../foo/bar');\nconst foo = foo$0.default || foo$0;`);
-	t.end();
-});
-
-// Double quotes
-
-test(`import foo from "foo"`, t => {
-	t.is(fn(`import foo from "foo"`), `const foo$0 = require('foo');\nconst foo = foo$0.default || foo$0;`);
-	t.end();
-});
-
-test(`import foo from "foo";`, t => {
-	t.is(fn(`import foo from "foo";`), `const foo$0 = require('foo');\nconst foo = foo$0.default || foo$0;`);
-	t.end();
-});
-
-test(`import foo from "./foo"`, t => {
-	t.is(fn(`import foo from "./foo"`), `const foo$0 = require('./foo');\nconst foo = foo$0.default || foo$0;`);
-	t.end();
-});
-
-test(`import foo from "../foo/bar"`, t => {
-	t.is(fn(`import foo from "../foo/bar"`), `const foo$0 = require('../foo/bar');\nconst foo = foo$0.default || foo$0;`);
-	t.end();
-});
-
-test(`import foo from "../foo/bar";`, t => {
-	t.is(fn(`import foo from "../foo/bar";`), `const foo$0 = require('../foo/bar');\nconst foo = foo$0.default || foo$0;`);
-	t.end();
-});
-
-// Partial Imports
-
-test(`import { foo, bar } from 'baz'`, t => {
-	const out = `const baz$0 = require('baz');\nconst foo = baz$0.foo;\nconst bar = baz$0.bar;`;
-	t.is(fn(`import { foo, bar } from 'baz'`), out);
-	t.end();
-});
-
-test(`import { foo, bar } from '../baz'`, t => {
-	const out = `const baz$0 = require('../baz');\nconst foo = baz$0.foo;\nconst bar = baz$0.bar;`
-	t.is(fn(`import { foo, bar } from '../baz'`), out);
-	t.end();
-});
-
-// Mixed Imports
-
-test(`import baz, { foo, bar } from 'baz'`, t => {
-	const out = `const baz$0 = require('baz');
-const baz = baz$0.default || baz$0;
+	// Partial Imports
+	[
+		`import { foo, bar } from 'baz'`,
+		`const baz$0 = require('baz');
 const foo = baz$0.foo;
-const bar = baz$0.bar;`;
-	t.is(fn(`import baz, { foo, bar } from 'baz'`), out);
-	t.end();
-});
-
-test(`import baz, { foo, bar } from '../baz'`, t => {
-	const out = `const baz$0 = require('../baz');
-const baz = baz$0.default || baz$0;
+const bar = baz$0.bar;`
+	],
+	[
+		`import { foo, bar } from '../baz'`,
+		`const baz$0 = require('../baz');
 const foo = baz$0.foo;
-const bar = baz$0.bar;`;
-	t.is(fn(`import baz, { foo, bar } from '../baz'`), out);
-	t.end();
-});
+const bar = baz$0.bar;`
+	],
 
-test(`import baz, { foo } from 'baz';import bat, { foo as bar } from 'bat';`, t => {
-	const out = `const baz$0 = require('baz');
-const baz = baz$0.default || baz$0;
-const foo = baz$0.foo;const bat$1 = require('bat');
-const bat = bat$1.default || bat$1;
-const bar = bat$1.foo;`;
-	t.is(fn(`import baz, { foo } from 'baz';import bat, { foo as bar } from 'bat';`), out);
-	t.end();
-});
+	// Mixed Imports
+	[
+		`import baz, { foo, bar } from 'baz'`,
+		`function ri$interop(m) { return m.default || m }
+const baz = ri$interop(require('baz'));
+const foo = baz.foo;
+const bar = baz.bar;`
+	],
+	[
+		`import baz, { foo, bar } from '../baz'`,
+		`function ri$interop(m) { return m.default || m }
+const baz = ri$interop(require('../baz'));
+const foo = baz.foo;
+const bar = baz.bar;`
+	],
+	[
+		`import baz, { foo } from 'baz';import bat, { foo as bar } from 'bat';`,
+		`function ri$interop(m) { return m.default || m }
+const baz = ri$interop(require('baz'));
+const foo = baz.foo;const bat = ri$interop(require('bat'));
+const bar = bat.foo;`
+	],
+	[
+		`import baz, { foo as bar, bar as bat } from 'baz'`,
+		`function ri$interop(m) { return m.default || m }
+const baz = ri$interop(require('baz'));
+const bar = baz.foo;
+const bat = baz.bar;`
+	],
+	[
+		`import baz, {foo as bar} from 'baz';import quz, {foo as bat} from 'quz';`,
+		`function ri$interop(m) { return m.default || m }
+const baz = ri$interop(require('baz'));
+const bar = baz.foo;const quz = ri$interop(require('quz'));
+const bat = quz.foo;`
+	],
 
-test(`import baz, { foo as bar, bar as bat } from 'baz'`, t => {
-	const out = `const baz$0 = require('baz');
-const baz = baz$0.default || baz$0;
-const bar = baz$0.foo;
-const bat = baz$0.bar;`;
-	t.is(fn(`import baz, { foo as bar, bar as bat } from 'baz'`), out);
-	t.end();
-});
+	// Aliases
+	[
+		`import { default as main } from 'foo'`,
+		`const foo$0 = require('foo');
+const main = foo$0.default;`
+	],
+	[
+		`import { foo as bar } from 'baz'`,
+		`const baz$0 = require('baz');
+const bar = baz$0.foo;`
+	],
+	[
+		`import { bar, default as main } from '../foo'`,
+		`const foo$0 = require('../foo');
+const bar = foo$0.bar;
+const main = foo$0.default;`
+	],
+	[
+		`import { foo as bar, default as main } from '../foo'`,
+		`const foo$0 = require('../foo');
+const bar = foo$0.foo;
+const main = foo$0.default;`
+	],
+	[
+		`import baz, { foo as bar, default as main } from '../foo'`,
+		`function ri$interop(m) { return m.default || m }
+const baz = ri$interop(require('../foo'));
+const bar = baz.foo;
+const main = baz.default;`
+	],
+	[
+		`import * as foo from '../foo'`,
+		`function ri$interop(m) { return m.default || m }
+const foo = ri$interop(require('../foo'));`
+	],
 
-test(`import baz,{foo as bar} from 'baz';import quz,{foo as bat}from'quz';`, t => {
-	const out = `const baz$0 = require('baz');
-const baz = baz$0.default || baz$0;
-const bar = baz$0.foo;const quz$1 = require('quz');
-const quz = quz$1.default || quz$1;
-const bat = quz$1.foo;`;
-	t.is(fn(`import baz,{foo as bar} from 'baz';import quz,{foo as bat}from'quz';`), out);
-	t.end();
-});
+	// Raw imports
+	[
+		`import 'bar'`,
+		`require('bar');`
+	],
+	[
+		`import './foo';`,
+		`require('./foo');`
+	],
 
-// No spaces
+	// Multi-line
+	[
+		`import {
+	foo,
+	bar,
+	bat as baz
+} from 'baz'`,
+		`const baz$0 = require('baz');
+const foo = baz$0.foo;
+const bar = baz$0.bar;
+const baz = baz$0.bat;`
+	],
+	[
+		`import {
+	foo,
+	bar,
+	bat as baz
+} from '../baz'`,
+		`const baz$0 = require('../baz');
+const foo = baz$0.foo;
+const bar = baz$0.bar;
+const baz = baz$0.bat;`
+	],
 
-test(`import'foo'`, t => {
-	t.is(fn(`import'foo'`), `require('foo');`);
-	t.end();
-});
+	// Muiltiple statements
+	[
+		`import foo from 'foo';import bar from 'bar';`,
+		`function ri$interop(m) { return m.default || m }
+const foo = ri$interop(require('foo'));const bar = ri$interop(require('bar'));`
+	],
+	[
+		`import foo from 'foo'\nimport { baz1, baz2 } from 'baz'`,
+		`function ri$interop(m) { return m.default || m }
+const foo = ri$interop(require('foo'));
+const baz$0 = require('baz');
+const baz1 = baz$0.baz1;
+const baz2 = baz$0.baz2;`
+	],
+	[
+		`import 'bar';import './foo';`,
+		`require('bar');require('./foo');`
+	],
+	[
+		`import './foo'
+import 'bar'`,
+		`require('./foo');
+require('bar');`
+	],
 
-test(`import foo from'foo'`, t => {
-	t.is(fn(`import foo from'foo'`), `const foo$0 = require('foo');\nconst foo = foo$0.default || foo$0;`);
-	t.end();
-});
-
-test(`import{foo,bar}from'baz'`, t => {
-	const out = `const baz$0 = require('baz');\nconst foo = baz$0.foo;\nconst bar = baz$0.bar;`;
-	t.is(fn(`import{foo,bar}from'baz'`), out);
-	t.end();
-});
-
-test(`import{foo,bar}from'../baz'`, t => {
-	const out = `const baz$0 = require('../baz');\nconst foo = baz$0.foo;\nconst bar = baz$0.bar;`
-	t.is(fn(`import{foo,bar}from'../baz'`), out);
-	t.end();
-});
-
-// Dashes
-
-test(`import foo from "foo-bar"`, t => {
-	t.is(fn(`import foo from "foo-bar"`), `const foo$0 = require('foo-bar');\nconst foo = foo$0.default || foo$0;`);
-	t.end();
-});
-
-test(`import {foo, bar} from 'foo-bar'`, t => {
-	const out = `const foo_bar$0 = require('foo-bar');\nconst foo = foo_bar$0.foo;\nconst bar = foo_bar$0.bar;`
-	t.is(fn(`import {foo, bar} from 'foo-bar'`), out);
-	t.end();
-});
-
-// Aliases
-
-test(`import { default as main } from 'foo'`, t => {
-	t.is(fn(`import { default as main } from 'foo'`), `const foo$0 = require('foo');\nconst main = foo$0.default;`);
-	t.end();
-});
-
-test(`import { foo as bar } from 'baz'`, t => {
-	t.is(fn(`import { foo as bar } from 'baz'`), `const baz$0 = require('baz');\nconst bar = baz$0.foo;`);
-	t.end();
-});
-
-test(`import { bar, default as main } from '../foo'`, t => {
-	const out = `const foo$0 = require('../foo');\nconst bar = foo$0.bar;\nconst main = foo$0.default;`
-	t.is(fn(`import { bar, default as main } from '../foo'`), out);
-	t.end();
-});
-
-test(`import { foo as bar, default as main } from '../foo'`, t => {
-	const out = `const foo$0 = require('../foo');\nconst bar = foo$0.foo;\nconst main = foo$0.default;`
-	t.is(fn(`import { foo as bar, default as main } from '../foo'`), out);
-	t.end();
-});
-
-test(`import {foo as bar, default as main} from '../foo'`, t => {
-	const out = `const foo$0 = require('../foo');\nconst bar = foo$0.foo;\nconst main = foo$0.default;`
-	t.is(fn(`import {foo as bar, default as main} from '../foo'`), out);
-	t.end();
-});
-
-test(`import * as foo from '../foo'`, t => {
-	const out = `const foo$0 = require('../foo');\nconst foo = foo$0.default || foo$0;`
-	t.is(fn(`import * as foo from '../foo'`), out);
-	t.end();
-});
-
-// Raw imports
-
-test(`import 'bar'`, t => {
-	t.is(fn(`import 'bar'`), `require('bar');`);
-	t.end();
-});
-
-test(`import './foo';`, t => {
-	t.is(fn(`import './foo';`), `require('./foo');`);
-	t.end();
-});
-
-
-// Multi-line
-
-test(`multi-line -- named`, t => {
-	const str = `import {
-		foo,
-		bar,
-		bat as baz
-	} from 'baz'`;
-	const out = `const baz$0 = require('baz');\nconst foo = baz$0.foo;\nconst bar = baz$0.bar;\nconst baz = baz$0.bat;`;
-	t.is(fn(str), out);
-	t.end();
-});
-
-test(`multi-line -- relative`, t => {
-	const str = `import {
-		foo,
-		bar,
-		bat as baz
-	} from '../baz'`;
-	const out = `const baz$0 = require('../baz');\nconst foo = baz$0.foo;\nconst bar = baz$0.bar;\nconst baz = baz$0.bat;`
-	t.is(fn(str), out);
-	t.end();
-});
-
-// Muiltiple statements
-
-test(`import foo from 'foo';import bar from 'bar';`, t => {
-	const out = `const foo$0 = require('foo');
-const foo = foo$0.default || foo$0;const bar$1 = require('bar');
-const bar = bar$1.default || bar$1;`;
-	t.is(fn(`import foo from 'foo';import bar from 'bar';`), out);
-	t.end();
-});
-
-test(`import foo from 'foo'\\nimport { baz1, baz2 } from 'baz'`, t => {
-	const out = `const foo$0 = require('foo');
-const foo = foo$0.default || foo$0;
-const baz$1 = require('baz');
-const baz1 = baz$1.baz1;
-const baz2 = baz$1.baz2;`;
-	t.is(fn(`import foo from 'foo'\nimport { baz1, baz2 } from 'baz'`), out);
-	t.end();
-});
-
-test(`import 'bar';import './foo';`, t => {
-	t.is(fn(`import 'bar';import './foo';`), `require('bar');require('./foo');`);
-	t.end();
-});
-
-test(`import './foo'\\nimport 'bar'`, t => {
-	t.is(fn(`import './foo'\nimport 'bar'`), `require('./foo');\nrequire('bar');`);
-	t.end();
-});
-
-// Ensure Uniqueness
-
-test(`import { promisify } from 'util';import { foo as bar } from './util';`, t => {
-	const out = `const util$0 = require('util');\nconst promisify = util$0.promisify;const util$1 = require('./util');\nconst bar = util$1.foo;`;
-	t.is(fn(`import { promisify } from 'util';import { foo as bar } from './util';`), out);
-	t.end();
-});
-
-test(`import util, { promisify } from 'util';import { foo as bar } from './util';`, t => {
-	const out = `const util$0 = require('util');
-const util = util$0.default || util$0;
+	// Ensure Uniqueness
+	[
+		`import { promisify } from 'util';import { foo as bar } from './util';`,
+		`const util$0 = require('util');
 const promisify = util$0.promisify;const util$1 = require('./util');
-const bar = util$1.foo;`;
-	t.is(fn(`import util, { promisify } from 'util';import { foo as bar } from './util';`), out);
-	t.end();
-});
+const bar = util$1.foo;`
+	],
+	[
+		`import util, { promisify } from 'util';import { foo as bar } from './util';`,
+		`function ri$interop(m) { return m.default || m }
+const util = ri$interop(require('util'));
+const promisify = util.promisify;const util$0 = require('./util');
+const bar = util$0.foo;`
+	],
+	[
+		`import { h } from 'preact';import { Component } from 'preact';`,
+		`const preact$0 = require('preact');
+const h = preact$0.h;const preact$1 = require('preact');
+const Component = preact$1.Component;`
+	],
 
-test(`import { h } from 'preact';import { Component } from 'preact';`, t => {
-	const out = `const preact$0 = require('preact');\nconst h = preact$0.h;const preact$1 = require('preact');\nconst Component = preact$1.Component;`;
-	t.is(fn(`import { h } from 'preact';import { Component } from 'preact';`), out);
-	t.end();
-});
+	// No spaces
+	[
+		`import'foo'`,
+		`require('foo');`
+	],
+	[
+		`import foo from'foo'`,
+		`function ri$interop(m) { return m.default || m }
+const foo = ri$interop(require('foo'));`
+	],
+	[
+		`import{foo,bar}from'baz'`,
+		`const baz$0 = require('baz');
+const foo = baz$0.foo;
+const bar = baz$0.bar;`
+	],
+	[
+		`import{foo,bar}from'../baz'`,
+		`const baz$0 = require('../baz');
+const foo = baz$0.foo;
+const bar = baz$0.bar;`
+	],
+	[
+		`import{foo,bar as baz}from'../baz'`,
+		`const baz$0 = require('../baz');
+const foo = baz$0.foo;
+const baz = baz$0.bar;`
+	],
+
+	// Dashes
+	[
+		`import foo from "foo-bar"`,
+		`function ri$interop(m) { return m.default || m }
+const foo = ri$interop(require('foo-bar'));`
+	],
+	[
+		`import {foo, bar} from 'foo-bar'`,
+		`const foo_bar$0 = require('foo-bar');
+const foo = foo_bar$0.foo;
+const bar = foo_bar$0.bar;`
+	],
+	[
+		`import baz, {foo, bar} from 'foo-bar'`,
+		`function ri$interop(m) { return m.default || m }
+const baz = ri$interop(require('foo-bar'));
+const foo = baz.foo;
+const bar = baz.bar;`
+	],
+].forEach(([code, expected]) => {
+	test(code, t => {
+		const result = fn(code);
+		t.doesNotThrow(() => new Function(result), SyntaxError);
+		t.is(result, expected);
+		t.end();
+	})
+})

--- a/test/index.js
+++ b/test/index.js
@@ -4,54 +4,54 @@ const fn = require('../src');
 // Single quotes
 
 test(`import foo from 'foo'`, t => {
-	t.is(fn(`import foo from 'foo'`), `const foo = require('foo');`);
+	t.is(fn(`import foo from 'foo'`), `const foo$0 = require('foo');\nconst foo = foo$0.default || foo$0;`);
 	t.end();
 });
 
 test(`import foo from 'foo';`, t => {
-	t.is(fn(`import foo from 'foo';`), `const foo = require('foo');`);
+	t.is(fn(`import foo from 'foo';`), `const foo$0 = require('foo');\nconst foo = foo$0.default || foo$0;`);
 	t.end();
 });
 
 test(`import foo from './foo'`, t => {
-	t.is(fn(`import foo from './foo'`), `const foo = require('./foo');`);
+	t.is(fn(`import foo from './foo'`), `const foo$0 = require('./foo');\nconst foo = foo$0.default || foo$0;`);
 	t.end();
 });
 
 test(`import foo from '../foo/bar'`, t => {
-	t.is(fn(`import foo from '../foo/bar'`), `const foo = require('../foo/bar');`);
+	t.is(fn(`import foo from '../foo/bar'`), `const foo$0 = require('../foo/bar');\nconst foo = foo$0.default || foo$0;`);
 	t.end();
 });
 
 test(`import foo from '../foo/bar';`, t => {
-	t.is(fn(`import foo from '../foo/bar';`), `const foo = require('../foo/bar');`);
+	t.is(fn(`import foo from '../foo/bar';`), `const foo$0 = require('../foo/bar');\nconst foo = foo$0.default || foo$0;`);
 	t.end();
 });
 
 // Double quotes
 
 test(`import foo from "foo"`, t => {
-	t.is(fn(`import foo from "foo"`), `const foo = require('foo');`);
+	t.is(fn(`import foo from "foo"`), `const foo$0 = require('foo');\nconst foo = foo$0.default || foo$0;`);
 	t.end();
 });
 
 test(`import foo from "foo";`, t => {
-	t.is(fn(`import foo from "foo";`), `const foo = require('foo');`);
+	t.is(fn(`import foo from "foo";`), `const foo$0 = require('foo');\nconst foo = foo$0.default || foo$0;`);
 	t.end();
 });
 
 test(`import foo from "./foo"`, t => {
-	t.is(fn(`import foo from "./foo"`), `const foo = require('./foo');`);
+	t.is(fn(`import foo from "./foo"`), `const foo$0 = require('./foo');\nconst foo = foo$0.default || foo$0;`);
 	t.end();
 });
 
 test(`import foo from "../foo/bar"`, t => {
-	t.is(fn(`import foo from "../foo/bar"`), `const foo = require('../foo/bar');`);
+	t.is(fn(`import foo from "../foo/bar"`), `const foo$0 = require('../foo/bar');\nconst foo = foo$0.default || foo$0;`);
 	t.end();
 });
 
 test(`import foo from "../foo/bar";`, t => {
-	t.is(fn(`import foo from "../foo/bar";`), `const foo = require('../foo/bar');`);
+	t.is(fn(`import foo from "../foo/bar";`), `const foo$0 = require('../foo/bar');\nconst foo = foo$0.default || foo$0;`);
 	t.end();
 });
 
@@ -72,31 +72,48 @@ test(`import { foo, bar } from '../baz'`, t => {
 // Mixed Imports
 
 test(`import baz, { foo, bar } from 'baz'`, t => {
-	const out = `const baz = require('baz');\nconst foo = baz.foo;\nconst bar = baz.bar;`;
+	const out = `const baz$0 = require('baz');
+const baz = baz$0.default || baz$0;
+const foo = baz$0.foo;
+const bar = baz$0.bar;`;
 	t.is(fn(`import baz, { foo, bar } from 'baz'`), out);
 	t.end();
 });
 
 test(`import baz, { foo, bar } from '../baz'`, t => {
-	const out = `const baz = require('../baz');\nconst foo = baz.foo;\nconst bar = baz.bar;`;
+	const out = `const baz$0 = require('../baz');
+const baz = baz$0.default || baz$0;
+const foo = baz$0.foo;
+const bar = baz$0.bar;`;
 	t.is(fn(`import baz, { foo, bar } from '../baz'`), out);
 	t.end();
 });
 
 test(`import baz, { foo } from 'baz';import bat, { foo as bar } from 'bat';`, t => {
-	const out = `const baz = require('baz');\nconst foo = baz.foo;const bat = require('bat');\nconst bar = bat.foo;`;
+	const out = `const baz$0 = require('baz');
+const baz = baz$0.default || baz$0;
+const foo = baz$0.foo;const bat$1 = require('bat');
+const bat = bat$1.default || bat$1;
+const bar = bat$1.foo;`;
 	t.is(fn(`import baz, { foo } from 'baz';import bat, { foo as bar } from 'bat';`), out);
 	t.end();
 });
 
 test(`import baz, { foo as bar, bar as bat } from 'baz'`, t => {
-	const out = `const baz = require('baz');\nconst bar = baz.foo;\nconst bat = baz.bar;`;
+	const out = `const baz$0 = require('baz');
+const baz = baz$0.default || baz$0;
+const bar = baz$0.foo;
+const bat = baz$0.bar;`;
 	t.is(fn(`import baz, { foo as bar, bar as bat } from 'baz'`), out);
 	t.end();
 });
 
 test(`import baz,{foo as bar} from 'baz';import quz,{foo as bat}from'quz';`, t => {
-	const out = `const baz = require('baz');\nconst bar = baz.foo;const quz = require('quz');\nconst bat = quz.foo;`;
+	const out = `const baz$0 = require('baz');
+const baz = baz$0.default || baz$0;
+const bar = baz$0.foo;const quz$1 = require('quz');
+const quz = quz$1.default || quz$1;
+const bat = quz$1.foo;`;
 	t.is(fn(`import baz,{foo as bar} from 'baz';import quz,{foo as bat}from'quz';`), out);
 	t.end();
 });
@@ -109,7 +126,7 @@ test(`import'foo'`, t => {
 });
 
 test(`import foo from'foo'`, t => {
-	t.is(fn(`import foo from'foo'`), `const foo = require('foo');`);
+	t.is(fn(`import foo from'foo'`), `const foo$0 = require('foo');\nconst foo = foo$0.default || foo$0;`);
 	t.end();
 });
 
@@ -128,7 +145,7 @@ test(`import{foo,bar}from'../baz'`, t => {
 // Dashes
 
 test(`import foo from "foo-bar"`, t => {
-	t.is(fn(`import foo from "foo-bar"`), `const foo = require('foo-bar');`);
+	t.is(fn(`import foo from "foo-bar"`), `const foo$0 = require('foo-bar');\nconst foo = foo$0.default || foo$0;`);
 	t.end();
 });
 
@@ -169,7 +186,7 @@ test(`import {foo as bar, default as main} from '../foo'`, t => {
 });
 
 test(`import * as foo from '../foo'`, t => {
-	const out = `const foo = require('../foo');`
+	const out = `const foo$0 = require('../foo');\nconst foo = foo$0.default || foo$0;`
 	t.is(fn(`import * as foo from '../foo'`), out);
 	t.end();
 });
@@ -214,12 +231,20 @@ test(`multi-line -- relative`, t => {
 // Muiltiple statements
 
 test(`import foo from 'foo';import bar from 'bar';`, t => {
-	t.is(fn(`import foo from 'foo';import bar from 'bar';`), `const foo = require('foo');const bar = require('bar');`);
+	const out = `const foo$0 = require('foo');
+const foo = foo$0.default || foo$0;const bar$1 = require('bar');
+const bar = bar$1.default || bar$1;`;
+	t.is(fn(`import foo from 'foo';import bar from 'bar';`), out);
 	t.end();
 });
 
 test(`import foo from 'foo'\\nimport { baz1, baz2 } from 'baz'`, t => {
-	t.is(fn(`import foo from 'foo'\nimport { baz1, baz2 } from 'baz'`), `const foo = require('foo');\nconst baz$0 = require('baz');\nconst baz1 = baz$0.baz1;\nconst baz2 = baz$0.baz2;`);
+	const out = `const foo$0 = require('foo');
+const foo = foo$0.default || foo$0;
+const baz$1 = require('baz');
+const baz1 = baz$1.baz1;
+const baz2 = baz$1.baz2;`;
+	t.is(fn(`import foo from 'foo'\nimport { baz1, baz2 } from 'baz'`), out);
 	t.end();
 });
 
@@ -242,7 +267,10 @@ test(`import { promisify } from 'util';import { foo as bar } from './util';`, t 
 });
 
 test(`import util, { promisify } from 'util';import { foo as bar } from './util';`, t => {
-	const out = `const util = require('util');\nconst promisify = util.promisify;const util$0 = require('./util');\nconst bar = util$0.foo;`;
+	const out = `const util$0 = require('util');
+const util = util$0.default || util$0;
+const promisify = util$0.promisify;const util$1 = require('./util');
+const bar = util$1.foo;`;
 	t.is(fn(`import util, { promisify } from 'util';import { foo as bar } from './util';`), out);
 	t.end();
 });

--- a/test/index.js
+++ b/test/index.js
@@ -271,7 +271,10 @@ const baz = ri$interop(require('foo-bar'));
 const foo = baz.foo;
 const bar = baz.bar;`
 	],
-].forEach(([code, expected]) => {
+].forEach(arr => {
+	let code = arr[0];
+	let expected = arr[1];
+
 	test(code, t => {
 		const result = fn(code);
 		t.doesNotThrow(() => new Function(result), SyntaxError);

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const test = require('tape');
 const fn = require('../src');
 

--- a/test/index.js
+++ b/test/index.js
@@ -5,54 +5,54 @@ const fn = require('../src');
 	// Single quotes
 	[
 		`import foo from 'foo'`,
-		`function ri$interop(m) { return m.default || m }
+		`function ri$interop(m){return m.default||m}
 const foo = ri$interop(require('foo'));`
 	],
 	[
 		`import foo from 'foo';`,
-		`function ri$interop(m) { return m.default || m }
+		`function ri$interop(m){return m.default||m}
 const foo = ri$interop(require('foo'));`
 	],
 	[
 		`import foo from './foo'`,
-		`function ri$interop(m) { return m.default || m }
+		`function ri$interop(m){return m.default||m}
 const foo = ri$interop(require('./foo'));`
 	],
 	[
 		`import foo from '../foo/bar'`,
-		`function ri$interop(m) { return m.default || m }
+		`function ri$interop(m){return m.default||m}
 const foo = ri$interop(require('../foo/bar'));`
 	],
 	[
 		`import foo from '../foo/bar';`,
-		`function ri$interop(m) { return m.default || m }
+		`function ri$interop(m){return m.default||m}
 const foo = ri$interop(require('../foo/bar'));`
 	],
 
 	// Double quotes
 	[
 		`import foo from "foo"`,
-		`function ri$interop(m) { return m.default || m }
+		`function ri$interop(m){return m.default||m}
 const foo = ri$interop(require('foo'));`
 	],
 	[
 		`import foo from "foo";`,
-		`function ri$interop(m) { return m.default || m }
+		`function ri$interop(m){return m.default||m}
 const foo = ri$interop(require('foo'));`
 	],
 	[
 		`import foo from "./foo"`,
-		`function ri$interop(m) { return m.default || m }
+		`function ri$interop(m){return m.default||m}
 const foo = ri$interop(require('./foo'));`
 	],
 	[
 		`import foo from "../foo/bar"`,
-		`function ri$interop(m) { return m.default || m }
+		`function ri$interop(m){return m.default||m}
 const foo = ri$interop(require('../foo/bar'));`
 	],
 	[
 		`import foo from "../foo/bar";`,
-		`function ri$interop(m) { return m.default || m }
+		`function ri$interop(m){return m.default||m}
 const foo = ri$interop(require('../foo/bar'));`
 	],
 
@@ -73,35 +73,35 @@ const bar = baz$0.bar;`
 	// Mixed Imports
 	[
 		`import baz, { foo, bar } from 'baz'`,
-		`function ri$interop(m) { return m.default || m }
+		`function ri$interop(m){return m.default||m}
 const baz = ri$interop(require('baz'));
 const foo = baz.foo;
 const bar = baz.bar;`
 	],
 	[
 		`import baz, { foo, bar } from '../baz'`,
-		`function ri$interop(m) { return m.default || m }
+		`function ri$interop(m){return m.default||m}
 const baz = ri$interop(require('../baz'));
 const foo = baz.foo;
 const bar = baz.bar;`
 	],
 	[
 		`import baz, { foo } from 'baz';import bat, { foo as bar } from 'bat';`,
-		`function ri$interop(m) { return m.default || m }
+		`function ri$interop(m){return m.default||m}
 const baz = ri$interop(require('baz'));
 const foo = baz.foo;const bat = ri$interop(require('bat'));
 const bar = bat.foo;`
 	],
 	[
 		`import baz, { foo as bar, bar as bat } from 'baz'`,
-		`function ri$interop(m) { return m.default || m }
+		`function ri$interop(m){return m.default||m}
 const baz = ri$interop(require('baz'));
 const bar = baz.foo;
 const bat = baz.bar;`
 	],
 	[
 		`import baz, {foo as bar} from 'baz';import quz, {foo as bat} from 'quz';`,
-		`function ri$interop(m) { return m.default || m }
+		`function ri$interop(m){return m.default||m}
 const baz = ri$interop(require('baz'));
 const bar = baz.foo;const quz = ri$interop(require('quz'));
 const bat = quz.foo;`
@@ -132,14 +132,14 @@ const main = foo$0.default;`
 	],
 	[
 		`import baz, { foo as bar, default as main } from '../foo'`,
-		`function ri$interop(m) { return m.default || m }
+		`function ri$interop(m){return m.default||m}
 const baz = ri$interop(require('../foo'));
 const bar = baz.foo;
 const main = baz.default;`
 	],
 	[
 		`import * as foo from '../foo'`,
-		`function ri$interop(m) { return m.default || m }
+		`function ri$interop(m){return m.default||m}
 const foo = ri$interop(require('../foo'));`
 	],
 
@@ -180,12 +180,12 @@ const baz = baz$0.bat;`
 	// Muiltiple statements
 	[
 		`import foo from 'foo';import bar from 'bar';`,
-		`function ri$interop(m) { return m.default || m }
+		`function ri$interop(m){return m.default||m}
 const foo = ri$interop(require('foo'));const bar = ri$interop(require('bar'));`
 	],
 	[
 		`import foo from 'foo'\nimport { baz1, baz2 } from 'baz'`,
-		`function ri$interop(m) { return m.default || m }
+		`function ri$interop(m){return m.default||m}
 const foo = ri$interop(require('foo'));
 const baz$0 = require('baz');
 const baz1 = baz$0.baz1;
@@ -211,7 +211,7 @@ const bar = util$1.foo;`
 	],
 	[
 		`import util, { promisify } from 'util';import { foo as bar } from './util';`,
-		`function ri$interop(m) { return m.default || m }
+		`function ri$interop(m){return m.default||m}
 const util = ri$interop(require('util'));
 const promisify = util.promisify;const util$0 = require('./util');
 const bar = util$0.foo;`
@@ -230,7 +230,7 @@ const Component = preact$1.Component;`
 	],
 	[
 		`import foo from'foo'`,
-		`function ri$interop(m) { return m.default || m }
+		`function ri$interop(m){return m.default||m}
 const foo = ri$interop(require('foo'));`
 	],
 	[
@@ -255,7 +255,7 @@ const baz = baz$0.bar;`
 	// Dashes
 	[
 		`import foo from "foo-bar"`,
-		`function ri$interop(m) { return m.default || m }
+		`function ri$interop(m){return m.default||m}
 const foo = ri$interop(require('foo-bar'));`
 	],
 	[
@@ -266,7 +266,7 @@ const bar = foo_bar$0.bar;`
 	],
 	[
 		`import baz, {foo, bar} from 'foo-bar'`,
-		`function ri$interop(m) { return m.default || m }
+		`function ri$interop(m){return m.default||m}
 const baz = ri$interop(require('foo-bar'));
 const foo = baz.foo;
 const bar = baz.bar;`


### PR DESCRIPTION
`import Button from './Button'` should work the same way as `import {default as Button} from './Button'`.