### PR TITLE
Major: Generate destructured/partial requires

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
+  - 8
   - 6
-  - 4

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "lukeed.com"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "scripts": {
     "build": "node builder",

--- a/readme.md
+++ b/readme.md
@@ -1,16 +1,26 @@
 # rewrite-imports [![Build Status](https://travis-ci.org/lukeed/rewrite-imports.svg?branch=master)](https://travis-ci.org/lukeed/rewrite-imports)
 
-Transforms various `import` statements into ES5-compatible `require()` calls, using regular expressions.
+Transforms various `import` statements into `require()` calls, using regular expressions.
+
 
 ## Caveats
 
-* Returns a string and **does not** provide a runtime nor does it evaluate the output.
+This module returns a string and **does not** provide a runtime nor does it evaluate the output.
 
-  > :bulb: For this behavior, use [`rewrite-module`](https://github.com/lukeed/rewrite-module) or check out [`@taskr/esnext`](https://github.com/lukeed/taskr/tree/master/packages/esnext) for an example.
+> :bulb: For this behavior, use [`rewrite-module`](https://github.com/lukeed/rewrite-module) or check out [`@taskr/esnext`](https://github.com/lukeed/taskr/tree/master/packages/esnext) for an example.
 
-* Have [false positives](https://github.com/lukeed/rewrite-imports/issues/8), you may want to use an AST to find actual `import` statements before transformation.
+The output requires a JavaScript runtime that supports `require` calls and [destructuring assignments](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Object_destructuring) with Objects.
 
-  > :bulb: Check out an [example implementation](https://github.com/styleguidist/react-styleguidist/blob/82f22d217044dee6215e60696c39791ee168fc14/src/client/utils/transpileImports.js).
+  * At least `Node 6.x` is required
+
+  * Or, for browsers:
+    * A `require` shim is always needed – see [`fn`](#fn)
+    * Ensure your target browsers support destructuring – see [chart](https://kangax.github.io/compat-table/es6/#test-destructuring,_assignment)
+
+If you have [false positives](https://github.com/lukeed/rewrite-imports/issues/8), you may want to use an AST to find actual `import` statements before transformation.
+
+> Check out an [example implementation](https://github.com/styleguidist/react-styleguidist/blob/82f22d217044dee6215e60696c39791ee168fc14/src/client/utils/transpileImports.js).
+
 
 ## Install
 
@@ -22,35 +32,42 @@ $ npm install --save rewrite-imports
 ## Usage
 
 ```js
-const rewriteImports = require('rewrite-imports');
+const rImports = require('rewrite-imports');
 
-rewriteImports(`import foo from '../bar'`);
+rImports(`import foo from '../bar'`);
 //=> const foo = require('../bar');
 
-rewriteImports(`import { foo } from 'bar'`);
-//=> const bar$1 = require('bar');
-//=> const foo = bar$1.foo;
+rImports(`import { foo } from 'bar'`);
+//=> const { foo } = require('bar');
 
-rewriteImports(`import * as path from 'path';`);
+rImports(`import * as path from 'path';`);
 //=> const path = require('path');
 
-rewriteImports(`import { foo as bar, baz as bat, lol } from 'quz';`);
-//=> const quz$1 = require('quz');
-//=> const bar = quz$1.foo;
-//=> const bat = quz$1.baz;
-//=> const lol = quz$1.lol;
+rImports(`import { foo as bar, baz as bat, lol } from 'quz';`);
+//=> const { foo:bar, baz:bat, lol } = require('quz');
+
+rImports(`import foobar, { foo as FOO, bar } from 'foobar';`);
+//=> const foobar = require('foobar');
+//=> const { foo:FOO, bar } = foobar;
 ```
 
 
 ## API
 
-### rewriteImports(input)
+### rImports(input, fn)
 
 #### input
 Type: `String`
 
-An `import` statement. See [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) for valid Syntax.
+The `import` statement(s) or the code containing `import` statement(s).
 
+> See [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) for valid `import` statement syntax.
+
+#### fn
+Type: `String`<br>
+Default: `'require'`
+
+The `require`-like function name to use. Defaults to `require` but you may choose to pass the name of a custom shim function; for example, `__webpack_require__` may work for webpack in the browser.
 
 ## License
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,33 +3,32 @@
 const UNNAMED = /import\s*['"]([^'"]+)['"];?/gi;
 const NAMED = /import\s*(\*\s*as)?\s*(\w*?)\s*,?\s*(?:\{([\s\S]*?)\})?\s*from\s*['"]([^'"]+)['"];?/gi;
 
-function alias(key) {
-	key = key.trim();
-	let name = key.split(' as ');
-	(name.length > 1) && (key=name.shift());
-	return { key, name: name[0] };
+function destruct(keys, target) {
+	let tmp, out=[];
+	while (keys.length) {
+		tmp = keys.shift().trim().split(' as ');
+		out.push(tmp.join(':'));
+	}
+	return `const { ${ out.join(', ')} } = ${target};`;
 }
 
 function generate(keys, dep, base, fn) {
-	const tmp = base || (dep.split('/').pop().replace(/\W/g, '_') + '$' + num++); // uniqueness
-	const name = base || alias(tmp).name;
-
 	dep = `${fn}('${dep}')`;
 
-	let obj;
-	let out = `const ${name} = ${dep};`;
+	if (keys.length && !base) {
+		return destruct(keys, dep);
+	}
 
-	keys.forEach(key => {
-		obj = alias(key);
-		out += `\nconst ${obj.name} = ${tmp}.${obj.key};`;
-	});
+	let out = `const ${base} = ${dep};`;
+
+	if (keys.length) {
+		out += '\n' + destruct(keys, base);
+	}
 
 	return out;
 }
 
-let num;
 module.exports = function (str, fn) {
-	num = 0;
 	fn = fn || 'require';
 	return str
 		.replace(NAMED, (_, asterisk, base, req, dep) => generate(req ? req.split(',') : [], dep, base, fn))

--- a/test/index.js
+++ b/test/index.js
@@ -51,77 +51,63 @@ const fn = require('../src');
 	// Partial Imports
 	[
 		`import { foo, bar } from 'baz'`,
-		`const baz$0 = require('baz');
-const foo = baz$0.foo;
-const bar = baz$0.bar;`
+		`const { foo, bar } = require('baz');`
 	],
 	[
 		`import { foo, bar } from '../baz'`,
-		`const baz$0 = require('../baz');
-const foo = baz$0.foo;
-const bar = baz$0.bar;`
+		`const { foo, bar } = require('../baz');`
 	],
 
 	// Mixed Imports
 	[
 		`import baz, { foo, bar } from 'baz'`,
 		`const baz = require('baz');
-const foo = baz.foo;
-const bar = baz.bar;`
+const { foo, bar } = baz;`
 	],
 	[
 		`import baz, { foo, bar } from '../baz'`,
 		`const baz = require('../baz');
-const foo = baz.foo;
-const bar = baz.bar;`
+const { foo, bar } = baz;`
 	],
 	[
 		`import baz, { foo } from 'baz';import bat, { foo as bar } from 'bat';`,
 		`const baz = require('baz');
-const foo = baz.foo;const bat = require('bat');
-const bar = bat.foo;`
+const { foo } = baz;const bat = require('bat');
+const { foo:bar } = bat;`
 	],
 	[
 		`import baz, { foo as bar, bar as bat } from 'baz'`,
 		`const baz = require('baz');
-const bar = baz.foo;
-const bat = baz.bar;`
+const { foo:bar, bar:bat } = baz;`
 	],
 	[
 		`import baz, {foo as bar} from 'baz';import quz, {foo as bat} from 'quz';`,
 		`const baz = require('baz');
-const bar = baz.foo;const quz = require('quz');
-const bat = quz.foo;`
+const { foo:bar } = baz;const quz = require('quz');
+const { foo:bat } = quz;`
 	],
 
 	// Aliases
 	[
 		`import { default as main } from 'foo'`,
-		`const foo$0 = require('foo');
-const main = foo$0.default;`
+		`const { default:main } = require('foo');`
 	],
 	[
 		`import { foo as bar } from 'baz'`,
-		`const baz$0 = require('baz');
-const bar = baz$0.foo;`
+		`const { foo:bar } = require('baz');`
 	],
 	[
 		`import { bar, default as main } from '../foo'`,
-		`const foo$0 = require('../foo');
-const bar = foo$0.bar;
-const main = foo$0.default;`
+		`const { bar, default:main } = require('../foo');`
 	],
 	[
 		`import { foo as bar, default as main } from '../foo'`,
-		`const foo$0 = require('../foo');
-const bar = foo$0.foo;
-const main = foo$0.default;`
+		`const { foo:bar, default:main } = require('../foo');`
 	],
 	[
 		`import baz, { foo as bar, default as main } from '../foo'`,
 		`const baz = require('../foo');
-const bar = baz.foo;
-const main = baz.default;`
+const { foo:bar, default:main } = baz;`
 	],
 	[
 		`import * as foo from '../foo'`,
@@ -145,10 +131,7 @@ const main = baz.default;`
 	bar,
 	bat as baz
 } from 'baz'`,
-		`const baz$0 = require('baz');
-const foo = baz$0.foo;
-const bar = baz$0.bar;
-const baz = baz$0.bat;`
+		`const { foo, bar, bat:baz } = require('baz');`
 	],
 	[
 		`import {
@@ -156,10 +139,7 @@ const baz = baz$0.bat;`
 	bar,
 	bat as baz
 } from '../baz'`,
-		`const baz$0 = require('../baz');
-const foo = baz$0.foo;
-const bar = baz$0.bar;
-const baz = baz$0.bat;`
+		`const { foo, bar, bat:baz } = require('../baz');`
 	],
 
 	// Muiltiple statements
@@ -169,10 +149,7 @@ const baz = baz$0.bat;`
 	],
 	[
 		`import foo from 'foo'\nimport { baz1, baz2 } from 'baz'`,
-		`const foo = require('foo');
-const baz$0 = require('baz');
-const baz1 = baz$0.baz1;
-const baz2 = baz$0.baz2;`
+		`const foo = require('foo');\nconst { baz1, baz2 } = require('baz');`
 	],
 	[
 		`import 'bar';import './foo';`,
@@ -188,21 +165,17 @@ require('bar');`
 	// Ensure Uniqueness
 	[
 		`import { promisify } from 'util';import { foo as bar } from './util';`,
-		`const util$0 = require('util');
-const promisify = util$0.promisify;const util$1 = require('./util');
-const bar = util$1.foo;`
+		`const { promisify } = require('util');const { foo:bar } = require('./util');`
 	],
 	[
-		`import util, { promisify } from 'util';import { foo as bar } from './util';`,
+		`import util, { promisify } from 'util';import helpers, { foo as bar } from './util';`,
 		`const util = require('util');
-const promisify = util.promisify;const util$0 = require('./util');
-const bar = util$0.foo;`
+const { promisify } = util;const helpers = require('./util');
+const { foo:bar } = helpers;`
 	],
 	[
 		`import { h } from 'preact';import { Component } from 'preact';`,
-		`const preact$0 = require('preact');
-const h = preact$0.h;const preact$1 = require('preact');
-const Component = preact$1.Component;`
+		`const { h } = require('preact');const { Component } = require('preact');`
 	],
 
 	// No spaces
@@ -216,21 +189,15 @@ const Component = preact$1.Component;`
 	],
 	[
 		`import{foo,bar}from'baz'`,
-		`const baz$0 = require('baz');
-const foo = baz$0.foo;
-const bar = baz$0.bar;`
+		`const { foo, bar } = require('baz');`
 	],
 	[
 		`import{foo,bar}from'../baz'`,
-		`const baz$0 = require('../baz');
-const foo = baz$0.foo;
-const bar = baz$0.bar;`
+		`const { foo, bar } = require('../baz');`
 	],
 	[
 		`import{foo,bar as baz}from'../baz'`,
-		`const baz$0 = require('../baz');
-const foo = baz$0.foo;
-const baz = baz$0.bar;`
+		`const { foo, bar:baz } = require('../baz');`
 	],
 
 	// Dashes
@@ -240,20 +207,15 @@ const baz = baz$0.bar;`
 	],
 	[
 		`import {foo, bar} from 'foo-bar'`,
-		`const foo_bar$0 = require('foo-bar');
-const foo = foo_bar$0.foo;
-const bar = foo_bar$0.bar;`
+		`const { foo, bar } = require('foo-bar');`
 	],
 	[
 		`import baz, {foo, bar} from 'foo-bar'`,
-		`const baz = require('foo-bar');
-const foo = baz.foo;
-const bar = baz.bar;`
+		`const baz = require('foo-bar');\nconst { foo, bar } = baz;`
 	],
 	[
 		`import a, {b} from 'c'`,
-		`const a = pizza('c');
-const b = a.b;`,
+		`const a = pizza('c');\nconst { b } = a;`,
 		'pizza'
 	],
 ].forEach(arr => {
@@ -267,4 +229,4 @@ const b = a.b;`,
 		t.is(result, expected);
 		t.end();
 	})
-})
+});


### PR DESCRIPTION
Is breaking due to the change in output – it would require updated runtime(s) to be supported.

This version also drops the need for checking/generating uniqueness of the dependency names. This is because we no longer are producing a middleman... which means that the source would have to be invalid in order for the output to be invalid. We trust the source.

_Closes #12_